### PR TITLE
Support grpc healthcheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support grpc-health-probe CLI exit code.
   - It's enabled by `collect_grpc_health_probe_status` option, append two metrics.
 - New metrics
-  - `network.grpc.health.errors(gauge)`: is incremented when grpc-health-probe CLI return non-zero exit codes.
-  - `network.grpc.health.exit_code(count)`: grpc-health-probe CLI exit code
+  - `network.grpc.health.errors(count)`: is incremented when grpc-health-probe CLI return non-zero exit codes.
+  - `network.grpc.health.exit_code(gauge)`: grpc-health-probe CLI exit code
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2022-09
+
+### Added
+- Support grpc-health-probe CLI exit code.
+  - It's enabled by `collect_grpc_health_probe_status` option, append two metrics.
+- New metrics
+  - `network.grpc.health.errors(gauge)`: is incremented when grpc-health-probe CLI return non-zero exit codes.
+  - `network.grpc.health.exit_code(count)`: grpc-health-probe CLI exit code
+

--- a/README.md
+++ b/README.md
@@ -12,15 +12,20 @@ datadog-grpc-check uses [grpc-health-probe](https://github.com/grpc-ecosystem/gr
 
 | Setting           | Description |
 | ------------------| ----------- |
-| server (Required) | Hostname or IP address of gRPC endpoint to check. |
-| port (Required)   | Port to check. |
-| connect_timeout   | Value of `--connect-timeout` option of grpc-health-probe (second). see [grpc-ecosystem/grpc-health-probe](https://github.com/grpc-ecosystem/grpc-health-probe#other-available-flags) |
-| rpc_timeout       | Value of `--rpc-timeout` option of grpc-health-probe (second). see [grpc-ecosystem/grpc-health-probe](https://github.com/grpc-ecosystem/grpc-health-probe#other-available-flags) |
-| tags              | List of tags. |
+| server (Required)                 | Hostname or IP address of gRPC endpoint to check. |
+| port (Required)                   | Port to check. |
+| connect_timeout                   | Value of `--connect-timeout` option of grpc-health-probe (second). see [grpc-ecosystem/grpc-health-probe](https://github.com/grpc-ecosystem/grpc-health-probe#other-available-flags) |
+| rpc_timeout                       | Value of `--rpc-timeout` option of grpc-health-probe (second). see [grpc-ecosystem/grpc-health-probe](https://github.com/grpc-ecosystem/grpc-health-probe#other-available-flags) |
+| tags                              | List of tags. |
+| collect_grpc_health_probe_status  | Collect grpc-health-probe CLI exit code and errors count metrics. Default: False |
 
 ## Metrics
 
-| Metrics                            | Description |
-| ---------------------------------- | ----------- |
-| network.grpc.response_time (gauge) | The response time (second) of a gRPC request to given target. |
-| network.grpc.can_connect (gauge)   | 1 if checks can connect and status success, 0 otherwise. |
+| Metrics                                   | Description |
+| ----------------------------------        | ----------- |
+| network.grpc.response_time (gauge)        | The response time (second) of a gRPC request to given target. |
+| network.grpc.can_connect (gauge)          | 1 if checks can connect and status success, 0 otherwise. |
+| network.grpc.health.exit_code (gauge)     | grpc-health-probe CLI exit code|
+| network.grpc.health.errors (count)        | Number of non-zero exit codes returned|
+
+

--- a/checks.d/grpc_check.py
+++ b/checks.d/grpc_check.py
@@ -42,7 +42,6 @@ class GrpcCheck(AgentCheck):
         elapsed = time.time() - start
 
         tags = self._get_tags()
-        tags.append('{}:{}'.format(self.TAG_EXIT_CODE, retcode))
 
         # Handle exit codes.
         # see https://github.com/grpc-ecosystem/grpc-health-probe#exit-codes
@@ -59,7 +58,8 @@ class GrpcCheck(AgentCheck):
         if self.collect_grpc_health_probe_status:
             self._gauge(self.METRICS_EXIT_CODE, retcode, tags=tags)
             if retcode != 0:
-                self.count(self.METRICS_ERRORS, 1, tags=tags)
+                exit_code_tag = '{}:{}'.format(self.TAG_EXIT_CODE, retcode)
+                self.count(self.METRICS_ERRORS, 1, tags=tags + [exit_code_tag])
 
     def _build_command(self):
         addr = "{}:{}".format(self.server, self.port)

--- a/checks.d/grpc_check.py
+++ b/checks.d/grpc_check.py
@@ -4,7 +4,7 @@ from datadog_checks.base import AgentCheck, ConfigurationError
 from datadog_checks.base.errors import CheckException
 from datadog_checks.base.utils.subprocess_output import get_subprocess_output
 
-__version__ = "0.0.3"
+__version__ = "0.1.0"
 
 
 class GrpcCheck(AgentCheck):

--- a/checks.d/grpc_check.py
+++ b/checks.d/grpc_check.py
@@ -4,7 +4,7 @@ from datadog_checks.base import AgentCheck, ConfigurationError
 from datadog_checks.base.errors import CheckException
 from datadog_checks.base.utils.subprocess_output import get_subprocess_output
 
-__version__ = "0.0.2"
+__version__ = "0.0.3"
 
 
 class GrpcCheck(AgentCheck):

--- a/checks.d/grpc_check.py
+++ b/checks.d/grpc_check.py
@@ -21,6 +21,7 @@ class GrpcCheck(AgentCheck):
         self.service = instance.get('service')
         self.connect_timeout = instance.get('connect_timeout', 10)
         self.rpc_timeout = instance.get('rpc_timeout', 10)
+        self.collect_grpc_health_probe_status = instance.get('collect_grpc_health_probe_status', False)
         self.tags = instance.get('tags', [])
 
         if not self.server:

--- a/checks.d/grpc_check.py
+++ b/checks.d/grpc_check.py
@@ -57,7 +57,7 @@ class GrpcCheck(AgentCheck):
             self._gauge(self.METRICS_CAN_CONNECT, 0, tags=tags)
 
         if self.collect_grpc_health_probe_status:
-            self._gauge(self.METRICS_EXIT_CODE, retcode, tags= tags)
+            self._gauge(self.METRICS_EXIT_CODE, retcode, tags=tags)
             if retcode != 0:
                 self.count(self.METRICS_ERRORS, 1, tags=tags)
 

--- a/conf.d/grpc_check.yaml.example
+++ b/conf.d/grpc_check.yaml.example
@@ -4,6 +4,7 @@ instances:
   - server: 192.0.2.10
     port: 50051
     service: helloworld.Greeter
+    collect_grpc_health_probe_status: False
     tags:
       - key1:val1
       - key2:val2
@@ -11,6 +12,7 @@ instances:
   - server: 192.0.2.11
     port: 50051
     service: helloworld.Greeter
+    collect_grpc_health_probe_status: False
     tags:
       - key3:val3
       - key4:val4

--- a/tests/test_grpc_check.py
+++ b/tests/test_grpc_check.py
@@ -159,8 +159,8 @@ class TestGrpcCheck(unittest.TestCase):
         check = grpc_check.GrpcCheck('grpc_check', {}, [instance])
         check.check(instance)
 
-        m_gauge.assert_any_call('network.grpc.can_connect', 1, tags=['addr:192.0.2.10:50051', 'grpc.health.exit_code:0'])
-        m_gauge.assert_any_call('network.grpc.response_time', ANY, tags=['addr:192.0.2.10:50051', 'grpc.health.exit_code:0'])
+        m_gauge.assert_any_call('network.grpc.can_connect', 1, tags=['addr:192.0.2.10:50051'])
+        m_gauge.assert_any_call('network.grpc.response_time', ANY, tags=['addr:192.0.2.10:50051'])
 
     @patch('grpc_check.GrpcCheck._gauge')
     @patch('grpc_check.get_subprocess_output')
@@ -174,7 +174,7 @@ class TestGrpcCheck(unittest.TestCase):
         check = grpc_check.GrpcCheck('grpc_check', {}, [instance])
         check.check(instance)
 
-        m_gauge.assert_any_call('network.grpc.can_connect', 0, tags=['addr:192.0.2.10:50051', 'grpc.health.exit_code:2'])
+        m_gauge.assert_any_call('network.grpc.can_connect', 0, tags=['addr:192.0.2.10:50051'])
 
     @patch('grpc_check.GrpcCheck._gauge')
     @patch('grpc_check.get_subprocess_output')

--- a/tests/test_grpc_check.py
+++ b/tests/test_grpc_check.py
@@ -159,8 +159,8 @@ class TestGrpcCheck(unittest.TestCase):
         check = grpc_check.GrpcCheck('grpc_check', {}, [instance])
         check.check(instance)
 
-        m_gauge.assert_any_call('network.grpc.can_connect', 1, tags=['addr:192.0.2.10:50051'])
-        m_gauge.assert_any_call('network.grpc.response_time', ANY, tags=['addr:192.0.2.10:50051'])
+        m_gauge.assert_any_call('network.grpc.can_connect', 1, tags=['addr:192.0.2.10:50051', 'grpc.health.exit_code:0'])
+        m_gauge.assert_any_call('network.grpc.response_time', ANY, tags=['addr:192.0.2.10:50051', 'grpc.health.exit_code:0'])
 
     @patch('grpc_check.GrpcCheck._gauge')
     @patch('grpc_check.get_subprocess_output')
@@ -174,7 +174,7 @@ class TestGrpcCheck(unittest.TestCase):
         check = grpc_check.GrpcCheck('grpc_check', {}, [instance])
         check.check(instance)
 
-        m_gauge.assert_any_call('network.grpc.can_connect', 0, tags=['addr:192.0.2.10:50051'])
+        m_gauge.assert_any_call('network.grpc.can_connect', 0, tags=['addr:192.0.2.10:50051', 'grpc.health.exit_code:2'])
 
     @patch('grpc_check.GrpcCheck._gauge')
     @patch('grpc_check.get_subprocess_output')

--- a/tests/test_grpc_check.py
+++ b/tests/test_grpc_check.py
@@ -25,6 +25,7 @@ class TestGrpcCheck(unittest.TestCase):
         self.assertEqual(check.service, 'helloworld.Greeter')
         self.assertEqual(check.connect_timeout, 10)
         self.assertEqual(check.rpc_timeout, 10)
+        self.assertEqual(check.collect_grpc_health_probe_status, False)
         self.assertEqual(check.tags, [])
 
     def test_constructor_param_timeout(self):
@@ -57,6 +58,16 @@ class TestGrpcCheck(unittest.TestCase):
         self.assertEqual(check.port, 50051)
         self.assertEqual(check.service, 'helloworld.Greeter')
         self.assertEqual(check.tags, ['key1:val1', 'key2:val2'])
+
+    def test_constructor_param_collect_grpc_health_probe_status(self):
+        instance = {
+            'server': '192.0.2.10',
+            'port': 50051,
+            'service': 'helloworld.Greeter',
+            'collect_grpc_health_probe_status': True,
+        }
+        check = grpc_check.GrpcCheck('grpc_check', {}, [instance])
+        self.assertEqual(check.collect_grpc_health_probe_status, True)
 
     def test_constructor_server_not_specified(self):
         instance = {

--- a/tests/test_grpc_health_probe.py
+++ b/tests/test_grpc_health_probe.py
@@ -38,7 +38,7 @@ class TestGrpcHealthProbe(unittest.TestCase):
         check = grpc_check.GrpcCheck('grpc_check', {}, [instance])
         check.check(instance)
 
-        expected_tags = ['addr:localhost:50051', 'service:helloworld.GreeterHealthy', 'grpc.health.exit_code:0']
+        expected_tags = ['addr:localhost:50051', 'service:helloworld.GreeterHealthy']
         m_gauge.assert_any_call('network.grpc.can_connect', 1, tags=expected_tags)
         m_gauge.assert_any_call('network.grpc.response_time', ANY, tags=expected_tags)
 
@@ -53,7 +53,7 @@ class TestGrpcHealthProbe(unittest.TestCase):
         check = grpc_check.GrpcCheck('grpc_check', {}, [instance])
         check.check(instance)
 
-        expected_tags = ['key1:val1', 'key2:val2', 'addr:localhost:50051', 'service:helloworld.GreeterHealthy', 'grpc.health.exit_code:0']
+        expected_tags = ['key1:val1', 'key2:val2', 'addr:localhost:50051', 'service:helloworld.GreeterHealthy']
         m_gauge.assert_any_call('network.grpc.can_connect', 1, tags=expected_tags)
         m_gauge.assert_any_call('network.grpc.response_time', ANY, tags=expected_tags)
 
@@ -67,7 +67,7 @@ class TestGrpcHealthProbe(unittest.TestCase):
         check = grpc_check.GrpcCheck('grpc_check', {}, [instance])
         check.check(instance)
 
-        expected_tags = ['addr:localhost:50051', 'service:helloworld.GreeterUnhealthy', 'grpc.health.exit_code:4']
+        expected_tags = ['addr:localhost:50051', 'service:helloworld.GreeterUnhealthy']
         m_gauge.assert_any_call('network.grpc.can_connect', 0, tags=expected_tags)
 
     @patch('grpc_check.GrpcCheck._gauge')
@@ -81,7 +81,7 @@ class TestGrpcHealthProbe(unittest.TestCase):
         check = grpc_check.GrpcCheck('grpc_check', {}, [instance])
         check.check(instance)
 
-        expected_tags = ['key1:val1', 'key2:val2', 'addr:localhost:50051', 'service:helloworld.GreeterUnhealthy', 'grpc.health.exit_code:4']
+        expected_tags = ['key1:val1', 'key2:val2', 'addr:localhost:50051', 'service:helloworld.GreeterUnhealthy']
         m_gauge.assert_any_call('network.grpc.can_connect', 0, tags=expected_tags)
 
     @patch('grpc_check.GrpcCheck._gauge')
@@ -97,10 +97,28 @@ class TestGrpcHealthProbe(unittest.TestCase):
         check = grpc_check.GrpcCheck('grpc_check', {}, [instance])
         check.check(instance)
 
-        expected_tags = ['addr:localhost:50051', 'service:helloworld.GreeterUnhealthy', 'grpc.health.exit_code:4']
+        expected_tags = ['addr:localhost:50051', 'service:helloworld.GreeterUnhealthy']
 
         m_gauge.assert_any_call(grpc_check.GrpcCheck.METRICS_EXIT_CODE, 4, tags=expected_tags)
-        m_count.assert_any_call(grpc_check.GrpcCheck.METRICS_ERRORS, 1, tags=expected_tags)
+        m_count.assert_any_call(grpc_check.GrpcCheck.METRICS_ERRORS, 1, tags=expected_tags + ['grpc.health.exit_code:4'])
+
+    @patch('grpc_check.GrpcCheck._gauge')
+    @patch('datadog_checks.base.AgentCheck.count')
+    def test_exit_code_tag_is_only_append_to_errors_metric(self, m_count, m_gauge):
+        instance = {
+            'server': 'localhost',
+            'port': 50051,
+            'service': 'helloworld.GreeterUnhealthy',
+            'collect_grpc_health_probe_status': True
+        }
+
+        check = grpc_check.GrpcCheck('grpc_check', {}, [instance])
+        check.check(instance)
+
+        expected_tags = ['addr:localhost:50051', 'service:helloworld.GreeterUnhealthy']
+
+        m_gauge.assert_any_call(grpc_check.GrpcCheck.METRICS_EXIT_CODE, 4, tags=expected_tags)
+        m_count.assert_any_call(grpc_check.GrpcCheck.METRICS_ERRORS, 1, tags=expected_tags + ['grpc.health.exit_code:4'])
 
 
     @patch('datadog_checks.base.AgentCheck.count')

--- a/tests/test_grpc_health_probe.py
+++ b/tests/test_grpc_health_probe.py
@@ -31,12 +31,13 @@ class TestGrpcHealthProbe(unittest.TestCase):
         instance = {
             'server': 'localhost',
             'port': 50051,
-            'service': 'helloworld.GreeterHealthy'
+            'service': 'helloworld.GreeterHealthy',
+            'collect_grpc_health_probe_status': False
         }
         check = grpc_check.GrpcCheck('grpc_check', {}, [instance])
         check.check(instance)
 
-        expected_tags = ['addr:localhost:50051', 'service:helloworld.GreeterHealthy']
+        expected_tags = ['addr:localhost:50051', 'service:helloworld.GreeterHealthy', 'grpc.health.exit_code:0']
         m_gauge.assert_any_call('network.grpc.can_connect', 1, tags=expected_tags)
         m_gauge.assert_any_call('network.grpc.response_time', ANY, tags=expected_tags)
 
@@ -51,7 +52,7 @@ class TestGrpcHealthProbe(unittest.TestCase):
         check = grpc_check.GrpcCheck('grpc_check', {}, [instance])
         check.check(instance)
 
-        expected_tags = ['key1:val1', 'key2:val2', 'addr:localhost:50051', 'service:helloworld.GreeterHealthy']
+        expected_tags = ['key1:val1', 'key2:val2', 'addr:localhost:50051', 'service:helloworld.GreeterHealthy', 'grpc.health.exit_code:0']
         m_gauge.assert_any_call('network.grpc.can_connect', 1, tags=expected_tags)
         m_gauge.assert_any_call('network.grpc.response_time', ANY, tags=expected_tags)
 
@@ -65,7 +66,7 @@ class TestGrpcHealthProbe(unittest.TestCase):
         check = grpc_check.GrpcCheck('grpc_check', {}, [instance])
         check.check(instance)
 
-        expected_tags = ['addr:localhost:50051', 'service:helloworld.GreeterUnhealthy']
+        expected_tags = ['addr:localhost:50051', 'service:helloworld.GreeterUnhealthy', 'grpc.health.exit_code:4']
         m_gauge.assert_any_call('network.grpc.can_connect', 0, tags=expected_tags)
 
     @patch('grpc_check.GrpcCheck._gauge')
@@ -79,8 +80,9 @@ class TestGrpcHealthProbe(unittest.TestCase):
         check = grpc_check.GrpcCheck('grpc_check', {}, [instance])
         check.check(instance)
 
-        expected_tags = ['key1:val1', 'key2:val2', 'addr:localhost:50051', 'service:helloworld.GreeterUnhealthy']
+        expected_tags = ['key1:val1', 'key2:val2', 'addr:localhost:50051', 'service:helloworld.GreeterUnhealthy', 'grpc.health.exit_code:4']
         m_gauge.assert_any_call('network.grpc.can_connect', 0, tags=expected_tags)
+
 
     def test_grpc_health_probe_invalid_option(self):
         instance = {

--- a/tests/test_grpc_health_probe.py
+++ b/tests/test_grpc_health_probe.py
@@ -9,6 +9,7 @@ from grpc_health.v1 import health
 from grpc_health.v1 import health_pb2
 from grpc_health.v1 import health_pb2_grpc
 
+from datadog_checks.base import AgentCheck
 from datadog_checks.base.errors import CheckException
 
 sys.path.append('{}/../checks.d/'.format(os.path.dirname(__file__)))
@@ -83,6 +84,39 @@ class TestGrpcHealthProbe(unittest.TestCase):
         expected_tags = ['key1:val1', 'key2:val2', 'addr:localhost:50051', 'service:helloworld.GreeterUnhealthy', 'grpc.health.exit_code:4']
         m_gauge.assert_any_call('network.grpc.can_connect', 0, tags=expected_tags)
 
+    @patch('grpc_check.GrpcCheck._gauge')
+    @patch('datadog_checks.base.AgentCheck.count')
+    def test_collect_health_probe_exit_code_metrics_when_collect_option_true(self, m_count, m_gauge):
+        instance = {
+            'server': 'localhost',
+            'port': 50051,
+            'service': 'helloworld.GreeterUnhealthy',
+            'collect_grpc_health_probe_status': True
+        }
+
+        check = grpc_check.GrpcCheck('grpc_check', {}, [instance])
+        check.check(instance)
+
+        expected_tags = ['addr:localhost:50051', 'service:helloworld.GreeterUnhealthy', 'grpc.health.exit_code:4']
+
+        m_gauge.assert_any_call(grpc_check.GrpcCheck.METRICS_EXIT_CODE, 4, tags=expected_tags)
+        m_count.assert_any_call(grpc_check.GrpcCheck.METRICS_ERRORS, 1, tags=expected_tags)
+
+
+    @patch('datadog_checks.base.AgentCheck.count')
+    @patch('grpc_check.GrpcCheck._gauge')
+    def test_do_not_collect_when_option_false(self, m_gauge, m_count):
+        instance = {
+            'server': 'localhost',
+            'port': 50051,
+            'service': 'helloworld.GreeterUnhealthy',
+            'collect_grpc_health_probe_status': False
+        }
+
+        check = grpc_check.GrpcCheck('grpc_check', {}, [instance])
+        check.check(instance)
+
+        m_count.assert_not_called()
 
     def test_grpc_health_probe_invalid_option(self):
         instance = {


### PR DESCRIPTION
# やったこと

- `grpc-health-probe` CLI exit code metricsを収集する機能を追加しました。
- config `collect_grpc_health_probe_status: True` の場合に、2つのメトリクスを追加で集計します。 
- 各metricsの `grpc.health.exit_code` tagにexit_code付与することによってグルーピング可能にしました。
- [CHANGELOG.md](https://github.com/topotal/datadog-grpc-check/blob/3cc8dddd6cc12c9732b9daf8565d1502794b12b0/CHANGELOG.md) の作成 🎉 

### 追加したメトリクス

- `network.grpc.health.exit_code(gauge)`
  - 接続失敗時にexit codeを保持します。
 - `network.grpc.health.errors(count)`
   - non-zero codeを失敗とみなしエラーをカウントします。これは`grpc.health.exit_code` tagを用いてexit code別にエラーを集計することが可能です

## Reviewしてほしい点

- metricsの集計対象の設計
- metrics key命名の妥当性
- exit_code tag命名の妥当性
- CHANGELOG導入したためセマンティックバージョンをサポートしたがよかったのか

### 確認方法

gRPCの[簡易ヘルスチェックサーバ](https://github.com/Sho2010/grpc-health-check)を作成しそれを用いて確認しました。

# 関連issue

- https://github.com/topotal/onboarding/issues/9
- https://github.com/topotal/SRE_wantedly/issues/91