### PR TITLE
Support extra arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2023-04
+
+### Added
+- Support grpc-health-probe CLI extra arguments
+  - It's enabled by `probe_extra_args` option.
+
 ## [0.1.0] - 2022-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ datadog-grpc-check uses [grpc-health-probe](https://github.com/grpc-ecosystem/gr
 | port (Required)                   | Port to check. |
 | connect_timeout                   | Value of `--connect-timeout` option of grpc-health-probe (second). see [grpc-ecosystem/grpc-health-probe](https://github.com/grpc-ecosystem/grpc-health-probe#other-available-flags) |
 | rpc_timeout                       | Value of `--rpc-timeout` option of grpc-health-probe (second). see [grpc-ecosystem/grpc-health-probe](https://github.com/grpc-ecosystem/grpc-health-probe#other-available-flags) |
+| probe_extra_args                  | Array of other arguments to send to grpc-health-probe. see [grpc-ecosystem/grpc-health-probe](https://github.com/grpc-ecosystem/grpc-health-probe#other-available-flags) |
 | tags                              | List of tags. |
 | collect_grpc_health_probe_status  | Collect grpc-health-probe CLI exit code and errors count metrics. Default: False |
 

--- a/checks.d/grpc_check.py
+++ b/checks.d/grpc_check.py
@@ -24,9 +24,11 @@ class GrpcCheck(AgentCheck):
         self.server = instance.get('server')
         self.port = instance.get('port')
         self.service = instance.get('service')
+        self.probe_extra_args = instance.get('probe_extra_args')
         self.connect_timeout = instance.get('connect_timeout', 10)
         self.rpc_timeout = instance.get('rpc_timeout', 10)
-        self.collect_grpc_health_probe_status = instance.get('collect_grpc_health_probe_status', False)
+        self.collect_grpc_health_probe_status = instance.get(
+            'collect_grpc_health_probe_status', False)
         self.tags = instance.get('tags', [])
 
         if not self.server:
@@ -38,7 +40,9 @@ class GrpcCheck(AgentCheck):
         command = self._build_command()
 
         start = time.time()
-        _, err, retcode = get_subprocess_output(command, self.log, raise_on_empty_output=False)
+        _, err, retcode = get_subprocess_output(command,
+                                                self.log,
+                                                raise_on_empty_output=False)
         elapsed = time.time() - start
 
         tags = self._get_tags()
@@ -68,9 +72,15 @@ class GrpcCheck(AgentCheck):
         if self.service:
             command = command + ['-service', self.service]
         if self.connect_timeout:
-            command = command + ['-connect-timeout', '{}s'.format(self.connect_timeout)]
+            command = command + [
+                '-connect-timeout', '{}s'.format(self.connect_timeout)
+            ]
         if self.rpc_timeout:
-            command = command + ['-rpc-timeout', '{}s'.format(self.rpc_timeout)]
+            command = command + [
+                '-rpc-timeout', '{}s'.format(self.rpc_timeout)
+            ]
+        if self.probe_extra_args:
+            command = command + self.probe_extra_args
         return command
 
     def _get_tags(self):

--- a/conf.d/grpc_check.yaml.example
+++ b/conf.d/grpc_check.yaml.example
@@ -13,6 +13,8 @@ instances:
     port: 50051
     service: helloworld.Greeter
     collect_grpc_health_probe_status: False
+    probe_extra_args:
+    - "-tls"
     tags:
       - key3:val3
       - key4:val4

--- a/tests/test_grpc_check.py
+++ b/tests/test_grpc_check.py
@@ -104,10 +104,14 @@ class TestGrpcCheck(unittest.TestCase):
         actual = check._build_command()
         expected = [
             'grpc-health-probe',
-            '-addr', '192.0.2.10:50051',
-            '-service', 'helloworld.Greeter',
-            '-connect-timeout', '10s',
-            '-rpc-timeout', '10s',
+            '-addr',
+            '192.0.2.10:50051',
+            '-service',
+            'helloworld.Greeter',
+            '-connect-timeout',
+            '10s',
+            '-rpc-timeout',
+            '10s',
         ]
         self.assertEqual(actual, expected)
 
@@ -133,7 +137,10 @@ class TestGrpcCheck(unittest.TestCase):
         check = grpc_check.GrpcCheck('grpc_check', {}, [instance])
 
         actual = check._get_tags()
-        expected = ['key1:val1', 'key2:val2', 'addr:192.0.2.10:50051', 'service:helloworld.Greeter']
+        expected = [
+            'key1:val1', 'key2:val2', 'addr:192.0.2.10:50051',
+            'service:helloworld.Greeter'
+        ]
         self.assertListEqual(actual, expected)
 
     def test_get_tags_service_not_specified(self):
@@ -147,6 +154,26 @@ class TestGrpcCheck(unittest.TestCase):
         expected = ['addr:192.0.2.10:50051']
         self.assertListEqual(actual, expected)
 
+    def test_constructor_param_probe_extra_args(self):
+        instance = {
+            'server': '192.0.2.10',
+            'port': 50051,
+            'service': 'helloworld.Greeter',
+            'connect_timeout': 100,
+            'rpc_timeout': 200,
+            'probe_extra_args': ['-tls', '-user-agent', 'custom-user-agent'],
+        }
+        check = grpc_check.GrpcCheck('grpc_check', {}, [instance])
+
+        self.assertEqual(check.server, '192.0.2.10')
+        self.assertEqual(check.port, 50051)
+        self.assertEqual(check.service, 'helloworld.Greeter')
+        self.assertEqual(check.connect_timeout, 100)
+        self.assertEqual(check.rpc_timeout, 200)
+        self.assertEqual(check.probe_extra_args,
+                         ['-tls', '-user-agent', 'custom-user-agent'])
+        self.assertEqual(check.tags, [])
+
     @patch('grpc_check.GrpcCheck._gauge')
     @patch('grpc_check.get_subprocess_output')
     def test_check_can_connect(self, m_get_subprocess_output, m_gauge):
@@ -159,8 +186,12 @@ class TestGrpcCheck(unittest.TestCase):
         check = grpc_check.GrpcCheck('grpc_check', {}, [instance])
         check.check(instance)
 
-        m_gauge.assert_any_call('network.grpc.can_connect', 1, tags=['addr:192.0.2.10:50051'])
-        m_gauge.assert_any_call('network.grpc.response_time', ANY, tags=['addr:192.0.2.10:50051'])
+        m_gauge.assert_any_call('network.grpc.can_connect',
+                                1,
+                                tags=['addr:192.0.2.10:50051'])
+        m_gauge.assert_any_call('network.grpc.response_time',
+                                ANY,
+                                tags=['addr:192.0.2.10:50051'])
 
     @patch('grpc_check.GrpcCheck._gauge')
     @patch('grpc_check.get_subprocess_output')
@@ -174,7 +205,9 @@ class TestGrpcCheck(unittest.TestCase):
         check = grpc_check.GrpcCheck('grpc_check', {}, [instance])
         check.check(instance)
 
-        m_gauge.assert_any_call('network.grpc.can_connect', 0, tags=['addr:192.0.2.10:50051'])
+        m_gauge.assert_any_call('network.grpc.can_connect',
+                                0,
+                                tags=['addr:192.0.2.10:50051'])
 
     @patch('grpc_check.GrpcCheck._gauge')
     @patch('grpc_check.get_subprocess_output')


### PR DESCRIPTION
## Why we need this
+ In our environment, we only expose grpc over tls

## How this PR solve it
+ I added 1 more option `probe_extra_args` so user can add more params such as tls parameters
https://github.com/grpc-ecosystem/grpc-health-probe#health-checking-tls-servers